### PR TITLE
Use go-ethereum master branch

### DIFF
--- a/merge-devnet.md
+++ b/merge-devnet.md
@@ -61,7 +61,7 @@ Clone Marius van der Wijden's Geth repository and switch to the `merge-kiln-v2` 
 
 ```console
 $ cd ~
-$ git clone -b merge-kiln-v2 https://github.com/MariusVanDerWijden/go-ethereum.git
+$ git clone -b master https://github.com/ethereum/go-ethereum.git
 ```
 
 Build this special Geth version.


### PR DESCRIPTION
The Kiln documentation for Geth was recently updated to use the `master` branch of Geth rather than Marius's forked repo. There was also a mention of this [here in the Eth Discord](https://discord.com/channels/595666850260713488/910910348922589184/964087245437014036).

https://notes.ethereum.org/@launchpad/kiln#Geth