### PR TITLE
Change Lighthouse to stable branch

### DIFF
--- a/merge-devnet.md
+++ b/merge-devnet.md
@@ -84,7 +84,7 @@ Clone the official Lighthouse repository and switch to the `unstable` branch.
 
 ```console
 $ cd ~
-$ git clone -b unstable https://github.com/sigp/lighthouse.git
+$ git clone -b stable https://github.com/sigp/lighthouse.git
 ```
 
 Build this special Lighthouse version.


### PR DESCRIPTION
There is a bug in the unstable branch of Lighthouse that causes the client to constantly restart. Stable branch is fine.
![image](https://user-images.githubusercontent.com/86061486/169619459-0644d6c4-6d00-4c6a-97df-f0363cd08e00.png)
