### PR TITLE
Fixed a few typos

### DIFF
--- a/merge-devnet.md
+++ b/merge-devnet.md
@@ -12,7 +12,7 @@ We will use the latest version of Geth and Lighthouse and we will configure them
 
 ## Executing the commands
 
-Almost all of these commands will be performed in a terminal. Start your *Terminal* application. Any line that starts with the dollar sign (`$`) is a command that need to be executed in your terminal. Do not input the dollar sign (`$`) in your terminal, only the text that comes after that.
+Almost all of these commands will be performed in a terminal. Start your *Terminal* application. Any line that starts with the dollar sign (`$`) is a command that needs to be executed in your terminal. Do not input the dollar sign (`$`) in your terminal, only the text that comes after that.
 
 Executing a command with `sudo` will occasionally ask you for your password. Make sure to enter your account password correctly. You can execute the command again if you fail to enter the correct password after a few attempts.
 
@@ -361,7 +361,7 @@ Press `Ctrl` + `C` to stop showing those messages.
 
 ## What's next?
 
-You performs a lot of different tasks to help with the [*#TestingTheMerge*](https://twitter.com/search?q=%23TestingTheMerge) initiave. Check out [the program structure](https://hackmd.io/WKpg6SNzQbi1jVKNgrSgWg). There are different tasks for all technical abilities.
+You performed a lot of different tasks to help with the [*#TestingTheMerge*](https://twitter.com/search?q=%23TestingTheMerge) initiative. Check out [the program structure](https://hackmd.io/WKpg6SNzQbi1jVKNgrSgWg). There are different tasks for all technical abilities.
 
 ## Good references
 


### PR DESCRIPTION
Few typo fixes
**BTW Can confirm that this guide works for Ubuntu 22.04 running on AARCH64 architecture (Apple M1 silicon). Line 45 in this file warns to 'be sure to use x86_64,' that could maybe be updated to allow ARM64?