### PR TITLE
Default to portable mev-boost build

### DIFF
--- a/prepare-for-the-merge.md
+++ b/prepare-for-the-merge.md
@@ -178,9 +178,8 @@ $ sudo useradd --no-create-home --shell /bin/false mevboost
 Install mev-boost globally.
 
 ```console
-$ cd ~ && git clone https://github.com/flashbots/mev-boost.git && cd mev-boost
-$ CGO_CFLAGS="-O -DBLST_PORTABLE" go build
-$ sudo cp ./mev-boost /usr/local/bin
+$ CGO_CFLAGS="-O -DBLST_PORTABLE" go install github.com/flashbots/mev-boost@latest
+$ sudo cp ~/go/bin/mev-boost /usr/local/bin
 $ sudo chown mevboost:mevboost /usr/local/bin/mev-boost
 ```
 

--- a/prepare-for-the-merge.md
+++ b/prepare-for-the-merge.md
@@ -178,8 +178,9 @@ $ sudo useradd --no-create-home --shell /bin/false mevboost
 Install mev-boost globally.
 
 ```console
-$ go install github.com/flashbots/mev-boost@latest
-$ sudo cp ~/go/bin/mev-boost /usr/local/bin
+$ cd ~ && git clone https://github.com/flashbots/mev-boost.git && cd mev-boost
+$ CGO_CFLAGS="-O -DBLST_PORTABLE" go build
+$ sudo cp ./mev-boost /usr/local/bin
 $ sudo chown mevboost:mevboost /usr/local/bin/mev-boost
 ```
 
@@ -249,6 +250,17 @@ through August 2022. When in doubt consult each client's `--help`.
 Tell systemd you made the changes: `sudo systemctl daemon-reload`
 
 And restart the service(s) you changed: `sudo systemctl restart SERVICENAME`
+
+### Update mev-boost
+
+When a new version is released, you can update mev-boost.
+
+```console
+$ cd ~/mev-boost && git pull
+$ CGO_CFLAGS="-O -DBLST_PORTABLE" go build
+$ sudo cp ./mev-boost /usr/local/bin
+$ sudo chown mevboost:mevboost /usr/local/bin/mev-boost
+```
 
 ## Support
 

--- a/prepare-for-the-merge.md
+++ b/prepare-for-the-merge.md
@@ -255,9 +255,8 @@ And restart the service(s) you changed: `sudo systemctl restart SERVICENAME`
 When a new version is released, you can update mev-boost.
 
 ```console
-$ cd ~/mev-boost && git pull
-$ CGO_CFLAGS="-O -DBLST_PORTABLE" go build
-$ sudo cp ./mev-boost /usr/local/bin
+$ CGO_CFLAGS="-O -DBLST_PORTABLE" go install github.com/flashbots/mev-boost@latest
+$ sudo cp ~/go/bin/mev-boost /usr/local/bin
 $ sudo chown mevboost:mevboost /usr/local/bin/mev-boost
 ```
 


### PR DESCRIPTION
We've had multiple users with pre-Broadwell CPUs who had issues. It's easiest to default to a portable build of mev-boost.