### PR TITLE
Portable Build Flag Fix

### DIFF
--- a/prepare-for-the-merge.md
+++ b/prepare-for-the-merge.md
@@ -284,7 +284,7 @@ And restart the service(s) you changed: `sudo systemctl restart SERVICENAME`
 When a new version is released, you can update mev-boost.
 
 ```console
-$ CGO_CFLAGS="-O -DBLST_PORTABLE" go install github.com/flashbots/mev-boost@latest
+$ CGO_CFLAGS=-"O -D__BLST_PORTABLE__" go install github.com/flashbots/mev-boost@latest
 $ sudo cp ~/go/bin/mev-boost /usr/local/bin
 $ sudo chown mevboost:mevboost /usr/local/bin/mev-boost
 ```


### PR DESCRIPTION
Updated go install command for portable install as the previous command can cause SIGILL crash for illegal instruction.  Fix proposed at FlashBots repo (https://github.com/flashbots/mev-boost#installing) and issue (https://github.com/flashbots/mev-boost/issues/256).