### PR TITLE
Consistent placement of quotes

### DIFF
--- a/prepare-for-the-merge.md
+++ b/prepare-for-the-merge.md
@@ -284,7 +284,7 @@ And restart the service(s) you changed: `sudo systemctl restart SERVICENAME`
 When a new version is released, you can update mev-boost.
 
 ```console
-$ CGO_CFLAGS=-"O -D__BLST_PORTABLE__" go install github.com/flashbots/mev-boost@latest
+$ CGO_CFLAGS="-O -D__BLST_PORTABLE__" go install github.com/flashbots/mev-boost@latest
 $ sudo cp ~/go/bin/mev-boost /usr/local/bin
 $ sudo chown mevboost:mevboost /usr/local/bin/mev-boost
 ```


### PR DESCRIPTION
for mev build. It's a minor thing, works either way, but would (hopefully) head off questions as to why it's in there two different ways.