### PR TITLE
Update the ExecStart for Geth Node Service

### DIFF
--- a/merge-goerli-prater.md
+++ b/merge-goerli-prater.md
@@ -97,7 +97,7 @@ Type=simple
 Restart=always
 RestartSec=5
 TimeoutStopSec=180
-ExecStart=geth \
+ExecStart=/usr/bin/geth \
     --goerli \
     --http \
     --datadir /var/lib/goethereum \


### PR DESCRIPTION
Changing to using absolute path to geth in `ExecStart` of `geth.service`

`geth.service` fails to start if the Executable path for the ExecStart is not absolute, and has following errors,

` [/etc/systemd/system/geth.service:13] Executable path is not absolute, ignoring: geth      --goerli ...`